### PR TITLE
move code table access outside ui thread

### DIFF
--- a/revolsys-core/src/main/java/com/revolsys/record/code/CodeTable.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/code/CodeTable.java
@@ -154,6 +154,24 @@ public interface CodeTable
 
   String getIdFieldName();
 
+  default void getMap(final Consumer<JsonObject> callback, final Identifier id) {
+    getValues(entry -> {
+      if (entry == null) {
+        callback.accept(JsonObject.EMPTY);
+      } else {
+        final JsonObject map = JsonObject.hash();
+        int i = 0;
+        for (final String name : getValueFieldNames()) {
+          final Object value = CodeTableEntry.getValues(entry).get(i);
+          map.addValue(name, value);
+          i++;
+        }
+        callback.accept(map);
+      }
+    }, id);
+
+  }
+
   default JsonObject getMap(final Identifier id) {
     final List<Object> values = getValues(id);
     if (values == null) {

--- a/revolsys-swing/src/main/java/com/revolsys/swing/map/layer/record/table/model/RecordLayerTableModel.java
+++ b/revolsys-swing/src/main/java/com/revolsys/swing/map/layer/record/table/model/RecordLayerTableModel.java
@@ -18,6 +18,7 @@ import javax.swing.JMenuItem;
 import javax.swing.ListSelectionModel;
 import javax.swing.RowFilter;
 import javax.swing.SortOrder;
+import javax.swing.SwingWorker;
 
 import org.jeometry.common.data.type.DataType;
 
@@ -626,7 +627,14 @@ public class RecordLayerTableModel extends RecordRowTableModel
 
   @Override
   protected void setRecordValueDo(final Record record, final String fieldName, final Object value) {
-    this.layer.setRecordValue((LayerRecord)record, fieldName, value);
+    Invoke.worker(new SwingWorker<Void, Void>() {
+      @Override
+      protected Void doInBackground() throws Exception {
+        RecordLayerTableModel.this.layer.setRecordValue((LayerRecord)record, fieldName, value);
+        return null;
+      }
+    });
+
   }
 
   @Override


### PR DESCRIPTION
Resolves a few of the code table lookups from the UI thread that were cause the desktop application to throw errors.