### PR TITLE
Transport Line Table UI Bug

### DIFF
--- a/revolsys-swing/src/main/java/com/revolsys/swing/map/layer/record/table/RecordLayerTablePanel.java
+++ b/revolsys-swing/src/main/java/com/revolsys/swing/map/layer/record/table/RecordLayerTablePanel.java
@@ -326,7 +326,9 @@ public class RecordLayerTablePanel extends TablePanel
         final TableCellEditor cellEditor = table.getCellEditor();
         cellEditor.stopCellEditing();
       }
-      final Point point = e.getPoint();
+
+      final Point point = new Point(e.getXOnScreen(), e.getYOnScreen());
+      SwingUtilities.convertPointFromScreen(point, table);
       final int row = table.rowAtPoint(point);
       final LayerRecord record = table.getRecord(row);
       this.layer.showForm(record);


### PR DESCRIPTION
On the table that lists all the transport lines, when double-clicking, the transport line edit dialog always opens with the record in the first row of the table even if you double clicked on the nth row.