### PR TITLE
issue #411 combo boxes not initialized

### DIFF
--- a/revolsys-swing/src/main/java/com/revolsys/swing/field/CodeTableComboBoxModel.java
+++ b/revolsys-swing/src/main/java/com/revolsys/swing/field/CodeTableComboBoxModel.java
@@ -72,6 +72,12 @@ public class CodeTableComboBoxModel extends AbstractListModel<Identifier>
     this.codeTable = codeTable;
     this.allowNull = allowNull;
     Property.addListener(codeTable, "valuesChanged", this);
+
+    if (!this.codeTable.isLoaded() && !this.codeTable.isLoading()) {
+      // force code table load
+      // https://apps.nrs.gov.bc.ca/geobcjira/browse/GBAAP-411
+      Invoke.background(null, () -> this.codeTable.refresh());
+    }
   }
 
   @Override


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/geobcjira/browse/GBAAP-411

There is a bit of a UI issue the first time this happens.  In the table view rather than a nice drop down you get a switcher. If you click elsewhere and go back to the field it turns back into a nice drop down. In the dialog view the drop down fields don't take the entire UI space horizontally.  These only happen the very first time (after loading the values; the UI isn't re-drawn).  I had a quick look for a redraw solution, but couldn't find out where it would happen, so for now I've decided not to fix this as it only happens the first time and there are higher priority issues.