### PR TITLE
#395 support names for batch updates

### DIFF
--- a/revolsys-core/src/main/java/com/revolsys/record/schema/FieldDefinition.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/schema/FieldDefinition.java
@@ -876,7 +876,7 @@ public class FieldDefinition extends BaseObjectWithProperties implements CharSeq
             return null;
           }
         }
-        if (this.codeTable != null && this.isIdField()) {
+        if (this.codeTable != null) {
           final Identifier identifier = this.codeTable.getIdentifier(value);
           if (identifier != null) {
             value = identifier.toSingleValue();


### PR DESCRIPTION
https://apps.nrs.gov.bc.ca/geobcjira/browse/GBAAP-395

This undoes a change I did ~6months ago that was associated with "fixed for GbaTools" tables. I tested the table editing in the tools app with this change and it seems to work fine, so not sure what the original purpose of this change was, but I don't think it should be there (it isn't there in the 4.x code base either).