### PR TITLE
476 - get the search to work properly

### DIFF
--- a/revolsys-core/src/main/java/com/revolsys/record/query/Value.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/Value.java
@@ -59,7 +59,11 @@ public class Value implements QueryValue {
   }
 
   public static Value newValue(final Object value) {
-    return newValue(JdbcFieldDefinitions.newFieldDefinition(value), value);
+    return newValue(value, false);
+  }
+
+  public static Value newValue(final Object value, final boolean dontConvert) {
+    return newValue(JdbcFieldDefinitions.newFieldDefinition(value), value, dontConvert);
   }
 
   private ColumnReference column;

--- a/revolsys-core/src/main/java/com/revolsys/record/query/functions/RegexpReplace.java
+++ b/revolsys-core/src/main/java/com/revolsys/record/query/functions/RegexpReplace.java
@@ -21,7 +21,8 @@ public class RegexpReplace extends SimpleFunction {
 
   public RegexpReplace(final QueryValue value, final String pattern, final String replace,
     final String flags) {
-    super(NAME, value, Value.newValue(pattern), Value.newValue(replace), Value.newValue(flags));
+    super(NAME, value, Value.newValue(pattern), Value.newValue(replace, true),
+      Value.newValue(flags));
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
https://wlrs-geobc.atlassian.net/browse/GBAAP-476

The search for the names was using the regex replace function like this:
REGEXP_REPLACE(UPPER("FULL_NAME"), ?, ?, ?)  LIKE  ?

The 'replace' value (second parameter) was provided as an empty string, however the code converted this to null which caused the query to return no results.  This fix does not convert the replace empty string to NULL.  It is limited to the replace value in REGEXG_REPLACE functions and won't affect other queries.